### PR TITLE
Same vademecum, new order of the contents

### DIFF
--- a/vademecum.tex
+++ b/vademecum.tex
@@ -176,17 +176,10 @@ In case you are in the position of resigning your residency status, you must sen
 More detailed information can be found at \href{http://www.welcomeoffice.fvg.it/practical-info/entry-and-stay/residence-registration-iscrizione-anagrafica/}{this} webpage, as well as by sending an e-mail to \linkemail{mobility@sissa.it}. Beware that this e-mail belongs to the International Relations Office, which in particular is in charge of helping foreign postdocs get their residency (as for them it is mandatory); they are always very willing to help out students who are having problems with their residency request.
 
 
-\chapter{\texorpdfstring{\faFileInvoiceDollar\ }{}INPS - Welfare Benefits}
-\label{sec:gestione_separata_inps}
-
-Even if for the Italian law you are regarded as a student and not as a worker, part of your fellowship is automatically (monthly) given to INPS, the national institution for welfare benefits, where they accumulate it for your future pension. In order to get access to this money (and actually many other benefits linked to possible illnesses or pregnancies), you must be registered to ``Gestione Separata'', a specific pension fund administred by INPS. The deadline to subscribe to ``Gestione Separata'' is $30$ days starting from the day on which SISSA notifies you of your admission to the PhD program. If you have already been registered to ``Gestione Separata'' (for example if you had a $150$-hours contract with an Italian university during your bachelor's or master's studies), just log into your personal INPS page (see \href{https://bit.ly/inpshome}{here}) and print the certification of your subscription. Otherwise, in order to subscribe to ``Gestione Separata'' you have to:
-\begin{enumerate}
-	\item get your SPID code, which allows to access all the online services of the Italian public administration. Following \href{https://www.spid.gov.it/richiedi-spid?lang=en-001}{this link}, you can get your SPID code (needed to log into your personal INPS webpage and get registered to ``Gestione Separata''). Note that it can take up to a few weeks to get your SPID number; therefore, the sooner you do it, the better it is. If you already have an INPS PIN, you do not need to get a SPID code and you can still log into the INPS portal by using your PIN code;
-	\item follow \href{https://www.inps.it/myinps/default.aspx?accessoinps=1}{this link} and log into your INPS personal webpage (using your INPS PIN number) and then subscribe to ``Gestione Separata'' under the contributor category named ``Parasubordinato''.
-\end{enumerate}
 
 
-\chapter{\texorpdfstring{\faGraduationCap\ }{}Research and Academic Life}
+\addcontentsline{toc}{part}{Part I - Life at SISSA}
+\chapter{\texorpdfstring{\faGraduationCap\ }{}Research, Academic Life and Beyond}
 
 So, now that you know where you are, you are probably willing to ask: what am I here for? The School's main job is to train you as an independent young scientist. From an academic viewpoint, research in SISSA is divided into three scientific Areas: \textbf{Physics}, \textbf{Mathematics} and \textbf{Neuroscience}. Moreover SISSA has an Interdisciplinary Laboratory which runs the MCS, a master course in science communication, and, jointly with ICTP and the Universities of Trieste and Udine, runs also the MHPC, a master course on high performance computing (see the dedicated \href{https://www.sissa.it/ilas/}{website} for more information).
 
@@ -258,10 +251,12 @@ Speaking of funds, you may also be interested in joining one of the national sci
 %\item \textbf{INFN} (Istituto Nazionale di Fisica Nucleare) and \textbf{INAF} (Istituto Nazionale di Astrofisica):
 % \url{http://home.infn.it/en/} \qquad \url{http://www.inaf.it/en?set_language=en}
 
-For long visiting periods within the EU (from 3 to 6 months), there is also the opportunity of \textbf{Erasmus Job Placement Fellowships}. The official announcements are forwarded by the Students Secretariat in September-October, with a deadline of about one month. Further information at \href{http://wiki.sissa.it/students/index.php/Erasmus_\%2B_Programme}{this link}.
+For long visiting periods within the EU (from 3 to 6 months), there is also the opportunity of \textbf{Erasmus Job Placement Fellowships}. The official announcements are forwarded by the Students Secretariat in September-October, with a deadline of about one month. Further information at \href{http://wiki.sissa.it/students/index.php/Erasmus_\%2B_Programme}{this link}. \\
+
+A contribution towards expenses for training and research activities may be assigned to PhD students enrolled in either their third \textbf{or} fourth year of the course. This contribution is, in particular, aimed to support the self-promotion of students during their search for postdoctoral position. The amount of money given is \EUR{} $1000$ and can be credited \textbf{una tantum} upon \textbf{request} of the student. For more detailed explanation, see the dedicated \href{https://wiki.sissa.it/students/index.php/Training_and_research_contribution}{webpage}.
 
 
-\section{After you get your Ph.D.}
+\section{SISSA Alumni Society}
 
 After you get your PhD title, the \href{https://alumni.sissa.it}{SISSA Alumni Society} is happy to welcome you. For more information contact them on:
 \begin{itemize}
@@ -350,34 +345,233 @@ To avoid receiving a huge number of personal packages delivered to the campus, t
 At the Post Office, you can also personalize your \hypertarget{Badge}{}\textbf{badge} with your photo, name, surname and date of birth printed on it. You will receive your badge shortly after your arrival at SISSA, simply ask for it at the Reception. It will grant you access to the external door on the second floor and more generally to the SISSA main building, laboratories and the library outside working hours.
 
 
-\section{Music Room and Kindergarten}
+\chapter{\texorpdfstring{\faFutbol\ }{}Extracurricular Activities}
+
+But enough with the boring and serious stuff! SISSA also cares about your leisure activities. Apart from the gym and the music room, these are some other extracurricular activities you can entertain yourself with.
+
+
+\section{SISSA Club}
+
+The \textbf{SISSA Club} offers you the possibility to attend many different activities which can also be proposed by the students and changed every year. Some examples include \textbf{sports, drawing classes, acting lessons, choir, dancing courses, photography classes, and a weekly cineclub}. 
+
+In the park (more precisely, in the B5 building), you may find the \textbf{Gym}. It is actually managed by the SISSA Club members that organize \textbf{fitness courses}. There you can work out and exercise, following the Latin motto ``\textit{mens sana in corpore sano}{}'' (``a sane mind in a healthy body''). 
+
+\textbf{Language courses}, including Italian for foreigners, are also among the available options in addition to scientific English courses. A subscription fee is required to join the Club: it will also cover your insurance if you participate in the sport activities. The SISSA Club can also admit people that are not in SISSA but want to enjoy time with us. For more information, please visit the \href{http://club.sissa.it/}{SISSA Club website}. 
+
+
+\section{SISSA for Schools}
+
+SISSA also opens its doors to guided visits to the School and the park for schools (ranging from primary to high school institutions). This project, called ``\textbf{SISSA for Schools}{}'' \ (``SISSA per la Scuola'' in Italian), is organized by \textbf{SISSA Medialab}, a SISSA spin-off company involved in science communication and many different activities. Weekly, seminars and other entertaining activities are offered to children with the aim of popularizing science. With the same aspiration, the ``\textbf{Student day}'' is yearly organized to host about 500 high school students willing to discover SISSA's research topics directly from students and professors. If you are interested in science communication, you are welcome to join the program and become a lecturer or a guide for the tours.  For the volunteers, SISSA Medialab organizes a training course in creative science communication for researchers (usually called ``\textit{Science dialogues}''). You can find additional information \href{http://medialab.sissa.it/sissaperlascuola/en}{here}.
+
+
+\section{Welcome Day and SISSA Parties}
+
+At the beginning of the academic year, a presentation of SISSA -- probably less interesting than the one you are reading {\dots} -- will take place in the Auditorium (Aula Magna) placed in front of the garden: this is the \textbf{Welcome Day} dedicated to first-year students. This is only one of the many social occasions where you will be able to get to know all your colleagues and new friends from SISSA, like the celebrated \textbf{SISSA Parties}. Remember that, among the secret mottoes of SISSA, there is: \textit{Study hard, party harder!} (The official one is ``ma per seguir virtute et canoscenza'', that is ``to follow virtue and knowledge'', quote from Dante's Inferno.) 
+
+
+\section{Neuroscience Experiments}
+
+An easy way to get some money and contribute to the advancement of science is to participate in the \textbf{experiments} that your colleagues from the Neuroscience Area conduct every day. These are announced on the Facebook group \href{https://www.facebook.com/groups/144096472323480}{``\textbf{Esperimenti SISSA}''} and also advertised via an e-mail newsletter from time to time; if you choose to help a neuroscientist out, you will be paid for your participation!
+
+\section{SISSA's Music Room}
 
 To look after your ``right side of the brain'', SISSA has also a \textbf{Music Room} made available for its students. There you will find a piano, drums and some amplifiers and other equipment you can use with your guitar; it is all free to use and at your disposal. In order to access this room, you have first to register with the Students Secretariat, and then you can book the room at your pleasure.
 
-The ``\textbf{SISSA per i piccoli}{}'' Kindergarten is open to all SISSA staff, including students, to take care of your children during working hours. For further information, see the dedicated \href{https://www.sissa.it/kindergarten}{webpage}.
+\chapter{\texorpdfstring{\faFlag\ }{}Student Representatives}
 
+If you are having some issues during your time at SISSA or you are simply curious about how the School works, the \textbf{student representatives} are there to help. Each PhD course has its own representative(s), who sit on the Area Council where all the important matters about your scientific Area are discussed (there are also \textit{supplementary} representatives in order to ensure the quorum is met). You will meet your representative(s) at the \emph{Student Council} presentation at the start of your PhD course. You can find the names and photos of all the representatives on the notice board in the Cafeteria, on the \href{http://students.sissa.it/}{website} and at the end of this section. Do not hesitate to write to them at \linkemail{studentreps@sissa.it} if you have any questions or problems related to your daily life in SISSA.
+
+Collectively, the student representatives constitute the \textbf{Student Council}. The Student Council is an advisory body concerned with decisions related to students' activities in the School, with a particular focus on teaching activities. The Council elects a President and a Vice-President. The President transmits the requests of the Council to the Director and to the Academic Senate, and submits an annual report on teaching activities and students' life in the School during the ordinary meetings of the School Council. The Student Council meets on a monthly basis to discuss all issues which are relevant to the whole student body and to convey those issues to the appropriate committees.
+
+In addition to the student representatives in the Area councils, there are representatives also in the
+\begin{itemize}
+	\item \textbf{Governing Bodies} of the School, which are the
+	\begin{itemize}
+		\item \textbf{Academic Senate}, which has the function of proposing general and strategic planning and coordinating the educational and scientific activities of the School;
+		\item \textbf{Board of Directors}, which has the power to approve the strategic planning, one-year and three-year financial plans and the personnel planning, as well as to monitor the financial sustainability of School activities;
+	\end{itemize}
+	\item \textbf{Advisory Bodies} of the School, which are the
+	\begin{itemize}
+		\item \textbf{School Council}, which is the consultative body that gathers all the School academic personnel (student representatives and research personnel) and technical and administrative personnel;
+		\item \textbf{Student-Professor Joint Committee}, which monitors the educational offerings, the quality of teaching and the quality of the services provided to students by the academic personnel;
+	\end{itemize}
+	\item \textbf{Supervisory Bodies} of the School, which are the
+	\begin{itemize}
+		\item \textbf{Evaluation Committee}, which is the body in charge of evaluating the quality of the teaching and research activities carried out by the academic personnel;
+		\item \textbf{Quality Assurance Unit}, which manages the implementation of the quality assurance procedures according to the guidelines defined by the Governing Bodies.
+	\end{itemize}
+\end{itemize}
+
+The Student-Professor Joint Committee, the Quality Assurance Unit and the Evaluation Committee work together in the quality assurance system developed by the School. SISSA is in fact dedicated to ensuring the high quality and continuous improvement of its academic standards. The School has developed and maintains periodic internal quality assurance policies and procedures with the involvement of all stakeholders to strengthen the quality culture within the institution. In order to measure the students degree of satisfaction about teaching and research activities, students' services and employability, the School carries out an annual students' survey that is solely for students officially enrolled in PhD courses at SISSA.
+
+For more information about the School quality assurance system visit \href{https://www.sissa.it/qualita}{this website}. You can find more information on the organization of the School's governing bodies on the dedicated \href{https://www.sissa.it/general-organization}{page}.
+
+It is a duty and pleasure for all the student representatives to help you get the best from your experience as a SISSA fellow. Feel free to contact them, either in person or by dropping them a line.
+
+Important updates relevant to students can also be found on a Facebook page managed by the student representatives themselves, click \href{https://www.facebook.com/groups/sissastudents/}{here} for jumping to it.
+
+% --- POSTER OF THE REPRESENTATIVES --- %
+\begin{figure}
+	\vspace*{-12pt}
+	\includegraphics[height=1.05\textheight,center]{StudentPoster}
+\end{figure}
+
+
+
+
+\chapter{\texorpdfstring{\faShieldVirus\ }{}SISSA During the COVID-19 Saga}
+
+In this chapter you can find essential information on the procedures that SISSA has employed in order to safeguard everybody's health in these tough times. Moreover, we also provide some useful tips with the hope of making your work at SISSA's facilities as comfortable as possible! \\
+This information is summarised below in the form of an FAQ. Visit SISSA's \href{https://www.sissa.it/news/covid-19-access-sissa-and-schools-activities}{webpage} for more details.
+
+
+\section{Can I Access SISSA?}
+
+All SISSA students are allowed to access the campus without specific authorisation. Within the School's opening hours, you can carry out both individual and lab-based research activities. Of course, common sense has to be applied! As always, we must keep a safe distance between each other and avoid grouping up. For this reason, you are strongly encouraged to work from home, unless coming to SISSA turns out to be strictly necessary or essential for your working well-being. \\
+Note that the use of spaces for research activities must comply with safety standards (e.g., distancing, use of PPE, etc.). So check for the presence of other people in shared offices and laboratories ahead of time, and book the facilities and common areas: in this way you will be able to work in peace and safety. \\
+If you have medical conditions which put you at a higher risk for COVID-19, please follow the directions provided by the Human Resources Office (e-mail: \linkemail{risorseumane@sissa.it}) and consult your healthcare provider (general practitioner or specialist) or SISSA's company doctor.
+
+
+\section{How Can I Get to SISSA?}
+
+\begin{itemize}
+	\item \textbf{By private vehicle or on foot} - The use of private vehicles must include only the presence of the driver if possible; if you want to bring someone with you, both of you must wear a facial mask or other protective equipment for covering your nose and mouth. During the trip, avoid the use of air conditioning and especially the recirculation function. These limits do not apply if vehicle occupants are cohabitants. It is recommended to arrive at SISSA between 8 AM and 8.30 AM to avoid creating long queues to enter with those using the private shuttle (see below).
+	
+	\item \textbf{By the SISSA shuttle} - If you do not have your own means of transport, or you prefer not to use it, you can use the shuttle service that SISSA has set up due to the COVID-19 emergency. The shuttle departs from the city centre and operates from Monday to Friday, excluding public holidays, with the following times and stops:
+	\begin{itemize}
+		\item Inbound: 7.55 AM (Largo Barriera) - 8 AM (Piazza Oberdan) - 8.25 AM (SISSA)
+		\item Inbound: 8.30 AM (Largo Barriera) - 8.35 AM (Piazza Oberdan) - 9 AM (SISSA)
+		\item Inbound: 9 AM (Largo Barriera) - 9.05 AM (Piazza Oberdan) - 9.30 AM (SISSA)
+		\item Outbound: 1:15 PM (SISSA) - 1:40 PM (Piazza Oberdan) - 1:45 PM (Largo Barriera)
+		\item Outbound: 7 PM (SISSA) - 7:25 PM (Piazza Oberdan) - 7:30 PM (Largo Barriera)
+	\end{itemize}
+	Remember that bookings are compulsory, and must be made before Thursday 8 AM the week in advance. On the shuttle, you must wear suitable protective equipment for covering the nose and mouth and respect a one-meter safety distance at least. In order to allow for social distancing, the shuttle will have limited capacity: only one person can use a seat row, with the exception of spouses or cohabiting family members. In the latter case it is sufficient to book 1 seat. \\
+	You can reserve your place on the shuttle \href{https://sissa-my.sharepoint.com/:x:/g/personal/tomicich_sissa_it/EawtTu5bUChBou8M1yikFLwB8AhuiMMCR-zscX84sRPWrQ?rtime=VgDdcu692Eg}{here}.
+	
+	\item \textbf{By public transport services} - As a (riskier) alternative, the bus line 38 is still active, while the bus number 64 will reach SISSA as soon as the extension of the square in front of the SISSA entrance has been completed.
+\end{itemize}
+
+
+\section{How Should I Behave Inside SISSA?}
+
+The maximum number of people who may be present at the same time in each shared room has been fixed for all areas in the main building, based on the overall amount of protection devices offered by SISSA to prevent the contagion, the available space, the time of stay and the activity carried out in a specific workplace. \\
+To avoid the so-called ``close contact'', it is necessary to ensure a low density of people and the respect of a minimum interpersonal distance of: 1 metre in transit areas (corridors); 2 metres in ``critical'' rest areas (coffee-break areas, smoking areas, etc.) and, unless otherwise specified, in common areas (including offices with more than one person). Note that a ``close contact'' is defined as a contact that occurs in a restricted environment (e.g. office) continuously for 15 minutes or more with an interpersonal distance of less than 2 metres.
+
+
+\subsection{Masks, Distances and Hygiene Measures}
+
+Keep a safe distance of at least 1 metre. In the corridors, on the stairs, in the bathrooms and in all common areas it is always recommended to wear the surgical mask provided at the entrance or the one in your possession, if considered suitable by the reception staff. Reduce your movements inside the SISSA building to those that are really necessary for your activity. Wash your hands frequently with soap and water, or alternatively with the dedicated cleansers placed on each floor of the School.
+
+
+\subsection{Cleaning the Workstation}
+
+Do not forget to clean frequently your desk and your workstation by means of the appropriate detergents. Be especially careful to clean well the infamous mouse-keyboard couple.
+
+
+\subsection{Ventilation of the Premises}
+
+Finally, it is a good idea to aerate your office as often as possible, so as to reduce further the probability of the infection transmission.
+
+
+\section{What About the Bar and Canteen Services?}
+
+As of \today\ the take-away service offered by the canteen is operative in a limited fashion, offering sandwiches, piadinas, pizza slices, salads and hot meals as well.
+
+Meals must be booked before 11 AM and collected between 12 PM and 1:30 PM. Bookings can be made:
+\begin{itemize}
+	\item through \href{https://www.sissa.it/cafeteria}{this link};
+	\item by e-mailing \linkemail{ristobar@sissa.it};
+	\item by using the paper register at the Reception.
+\end{itemize}
+
+If you are interested in receiving updates and communications from the canteen service via e-mail, you can subscribe to the cafeteria mailing list. This can be done by filling out the form that you find at \href{https://go.sissa.it/cafeteria}{this webpage} or by sending an e-mail from the address you want to subscribe with.
+
+\begin{comment}
+As of \today\ the bar is fully operational and open from 9:00 to 11:00 and from 14:00 to 15:00, while the canteen is open from 12:00 to 14:00.
+
+You can eat plated canteen food in the canteen by booking a specific time and place beforehand at \url{https://services.sissa.it/mensa/}. You can also get take-away meals (but \textbf{not} eat them in the canteen, even if you've booked a table) even without booking them in advance.
+
+If instead you prefer to get takeaway sandwiches/piadinas/salads, if have to book them in advance (by 11:00) in one of the following ways:
+\begin{itemize}
+\item on \url{https://www.sissa.it/cafeteria}
+\item by sending an email to \linkemail{ristobar@sissa.it}
+\item via the paper register at the reception
+\end{itemize}
+Sandwiches/piadinas/salads can then be collected at the canteen from 12:00 to 14:00.
+\end{comment}
+
+
+\section{Where Can I Retrieve Information on the Current Library Timetable and Rules?}
+
+Luckily, everything has a place in this world. \href{https://library.sissa.it/new-library-timetable-rules}{Here} you will find all the latest news on the status of the Library services.
+
+
+\section{Smart Working Toolbox}
+
+We list below some useful tips and reminders that hopefully could make your research activity at home more comfortable and less tiresome.
+\begin{itemize}
+	\item Did you know that SISSA provides each member of its academic staff with a Basic Zoom account for free? This allows you to organize virtual meetings with no time restrictions due to the number of people participating (as it occurs for the free subscription). Visit \url{https://www.itcs.sissa.it/lecturesonline} for more details!
+	
+	\item Not only Zoom, but also Overleaf has a special agreement with SISSA. You can claim your free Overleaf Professional account by signing up with a SISSA email (or by adding it to an existing Overleaf account). Notice that a Professional subscription poses no limits to the number of collaborators which you can share your projects with! More info: \url{https://www.overleaf.com/edu/sissa}.
+	
+	\item During your everyday research activity you may want to access the SISSA network remotely. Possible reasons: necessity of connecting to your workstation, extreme need of computational resources on the Ulysses cluster, exploiting the opportunity of having direct access to scientific papers (otherwise protected by paywalls) through the holy SISSA identity key. What you need is to establish a VPN remote connection with the SISSA internal network: follow the instructions at \url{https://www.itcs.sissa.it/services/computing/networkaccess}.
+	
+	\item Other tools that can help you get access to scientific papers while you are off-campus are also \href{https://scholar.google.com/intl/en/scholar/help.html\#access}{Google Scholar's Off-Campus Access}, that works by storing your library subscriptions for 30 days when you visit Google Scholar while on campus, \href{https://scholar.google.com/scholar_settings?sciifh=1\&as_sdt=0,5\#2}{Google Scholar's Library Links}, that lets you add a SISSA Library link next to every search result, and awesome free and open-source (fully legal) browser extensions like \href{https://unpaywall.org}{Unpaywall} (Chrome, Firefox), \href{https://www.oahelper.org}{Open Access Helper} (iOS, Safari on MacOS, Chrome, Firefox) and \href{https://openaccessbutton.org}{Open Access Button} (Chrome, Firefox, or by manually entering the DOI). If you also have a UniTS account, Open Access Helper lets you automatically use its EZProxy (more details \href{https://www.oahelper.org/ezproxy/}{here}) by just looking for ``units'' during the initial configuration.
+	
+	\item At these challenging times for our daily as well as academic life, SISSA has taken advantage of the Campus Initiative of Coursera, the leading platform for online learning. We encourage you to take a look at the courses available within the SISSA-Coursera agreement by registering at \href{https://www.coursera.org/programs/sissa-on-coursera-dkw8c}{this link} by using your SISSA e-mail. Should you find one or more courses that you wish to follow, please send an email to the Students Secretariat (e-mail: \linkemail{phd@sissa.it}) in order to have your account activated. Just a notice: some students reported that one needs to complete a course to have the possibility to subscribe to another one. You will not able to follow two different courses at the same time under the actual license rights.
+	
+	\item What would you say if we told that you are allowed to borrow the monitor of your workstation for the benefit of your home-made research? To do so, you have to write to prof. Antonio Lanza (e-mail: \linkemail{lanza@sissa.it}) with the inventory number of the monitor that you wish to get on loan. Make sure that the coordinator of your PhD sector is CC'd in your e-mail!
+\end{itemize}
+
+\section{The Final Piece of the Puzzle: Your Feedback!}
+We representatives are deeply aware of the continuing difficulties regarding your daily relationship with PhD-related activities, ranging from keeping in contact with your supervisor (a tough challenge in itself, sometimes) to even just managing to do some clean research without thinking excessively about the current situation. \\
+Do not hesitate to contact us should you have any problem regarding your PhD life, even if you do not understand some boring, bureaucratic stuff and you feel the need for some advice. We are still here for bridging the gap between your needs and the current workflow of SISSA.
+
+
+
+
+\addcontentsline{toc}{part}{Part II - Discounts, Support and Contributions}
+\chapter{\texorpdfstring{\faFileInvoiceDollar\ }{}INPS - Welfare Benefits}
+\label{sec:gestione_separata_inps}
+
+Even if for the Italian law you are regarded as a student and not as a worker, part of your fellowship is automatically (monthly) given to INPS, the national institution for welfare benefits, where they accumulate it for your future pension. In order to get access to this money (and actually many other benefits linked to possible illnesses or pregnancies), you must be registered to ``Gestione Separata'', a specific pension fund administred by INPS. The deadline to subscribe to ``Gestione Separata'' is $30$ days starting from the day on which SISSA notifies you of your admission to the PhD program. If you have already been registered to ``Gestione Separata'' (for example if you had a $150$-hours contract with an Italian university during your bachelor's or master's studies), just log into your personal INPS page (see \href{https://bit.ly/inpshome}{here}) and print the certification of your subscription. Otherwise, in order to subscribe to ``Gestione Separata'' you have to:
+\begin{enumerate}
+	\item get your SPID code, which allows to access all the online services of the Italian public administration. Following \href{https://www.spid.gov.it/richiedi-spid?lang=en-001}{this link}, you can get your SPID code (needed to log into your personal INPS webpage and get registered to ``Gestione Separata''). Note that it can take up to a few weeks to get your SPID number; therefore, the sooner you do it, the better it is. If you already have an INPS PIN, you do not need to get a SPID code and you can still log into the INPS portal by using your PIN code;
+	\item follow \href{https://www.inps.it/myinps/default.aspx?accessoinps=1}{this link} and log into your INPS personal webpage (using your INPS PIN number) and then subscribe to ``Gestione Separata'' under the contributor category named ``Parasubordinato''.
+\end{enumerate}
+
+Students who are forced to interrupt their activity due to \textbf{illness}, \textbf{severe personal problems} or \textbf{pregnancy} may be granted a contribution equal to $70\%$ of the fellowship for a maximum period of $5$ months. However, if you are working in a SISSA lab, in case of pregnancy your fellowship freezes starting from the day you notify the Students Secretariat and the Director by sending them a certificate vouching for your pregnancy. You will get a contribution equivalent to $70\%$ of the scholarship starting from the day of the notification of your pregnancy and ending seven months after the birth of your child. Also the date of your PhD defense is postponed by the appropriate length of time. Moreover, the Italian State provides for addition support to pregnant women. In order to gain access to these grants, you must be registered to the INPS pension fund called ``Gestione Separata'' (see Chapter \ref{sec:gestione_separata_inps} for more information);
 
 \chapter{\texorpdfstring{\faHandHoldingUsd\ }{}SISSA Support and Contributions}
 
-In addition to the PhD fellowship, SISSA offers supplementary contributions to its students:
+In addition to the PhD fellowship, SISSA offers supplementary contributions to its students.
 
-\begin{itemize}
-    \item a contribution towards \textbf{rent expanses} for students with a regular (registered) contract living in the province of Trieste (with a different domicile with respect to their family of origin). Every year the requests for the annual contributions towards living expenses must be submitted to the Students Secretariat no later than July $31$st through an ad-hoc form provided by the Secretariat itself; those who submit the request by July $31$st and have a rental contract that does not cover the entire period of the current year may subsequently (but not later than December $31$st) submit a second request to integrate it with details on the new rental contract or its renewal in order to cover the remaining period. The entire contribution will be paid in September. For those who submit an integration request, a second payment will be made by January/February in the following year. Students who are starting their first academic year will have to submit the application for the living expenses contribution no later than December $31$st in relation to the first year of the PhD. The contribution for the period from the beginning of the academic year to December will be paid by the end of February in the following year. All the details will be given to you by periodic reminders sent by the Secretariat and you can already find the dedicated form \href{http://wiki.sissa.it/students/index.php/Contribution_towards_living_expenses}{here};
+\section{Rent Expenses}
+ A contribution towards \textbf{rent expanses} for students with a regular (registered) contract living in the province of Trieste (with a different domicile with respect to their family of origin). Every year the requests for the annual contributions towards living expenses must be submitted to the Students Secretariat no later than July $31$st through an ad-hoc form provided by the Secretariat itself; those who submit the request by July $31$st and have a rental contract that does not cover the entire period of the current year may subsequently (but not later than December $31$st) submit a second request to integrate it with details on the new rental contract or its renewal in order to cover the remaining period. The entire contribution will be paid in September. For those who submit an integration request, a second payment will be made by January/February in the following year. Students who are starting their first academic year will have to submit the application for the living expenses contribution no later than December $31$st in relation to the first year of the PhD. The contribution for the period from the beginning of the academic year to December will be paid by the end of February in the following year. All the details will be given to you by periodic reminders sent by the Secretariat and you can already find the dedicated form \href{http://wiki.sissa.it/students/index.php/Contribution_towards_living_expenses}{here};
+ 
+     \section{Health Care Expenses} a contribution towards \textbf{health care} expenses (especially dental care); further information is available in \href{https://www.sissa.it/_media/documenti/english_regolamento_interventi.pdf}{English} and in \href{https://www.sissa.it/_media/documenti/regolamento-assistenziale.pdf}{Italian};
     
-    \item a \textbf{laptop} contribution, consisting in \EUR{} $400.00$ maximum for PhD students enrolled in the first and second years and \EUR{} $300.00$ maximum for PhD students enrolled in the third year. The deadline for the laptop purchase and for submitting the request is October $31$st every year. The bonus will be awarded only once and shall not exceed the price of the laptop. For further information, please visit the dedicated \href{http://wiki.sissa.it/students/index.php/Laptop_contribution}{webpage} on the SISSA Wiki (note that contrary to what the Wiki says, it \emph{is} possible use the laptop contribution to purchase a tablet);
+   \section{Laptop Contribution} 
+   A \textbf{laptop} contribution, consisting in \EUR{} $400.00$ maximum for PhD students enrolled in the first and second years and \EUR{} $300.00$ maximum for PhD students enrolled in the third year. The deadline for the laptop purchase and for submitting the request is October $31$st every year. The bonus will be awarded only once and shall not exceed the price of the laptop. For further information, please visit the dedicated \href{http://wiki.sissa.it/students/index.php/Laptop_contribution}{webpage} on the SISSA Wiki (note that contrary to what the Wiki says, it \emph{is} possible use the laptop contribution to purchase a tablet);
     
-    \item a contribution towards \textbf{health care} expenses (especially dental care); further information is available in \href{https://www.sissa.it/_media/documenti/english_regolamento_interventi.pdf}{English} and in \href{https://www.sissa.it/_media/documenti/regolamento-assistenziale.pdf}{Italian};
+
    
-    \item \textbf{part-time positions for students }($150$ Hours). Students are paid \EUR{} $10.30$ per hour working actively in various tasks at the base of life in SISSA, lasting from $50$ to $150$ hours depending on your availability, such as taking part in the Library administration, keeping the SISSA webpages updated, and so on. This income is tax-free. \textit{First year students cannot apply}, but keep this in mind in view of the following years. You can find more information \href{http://wiki.sissa.it/students/index.php/150_hours}{here};
+   \section{Part-time positions for students} \textbf{Part-time positions for students }($150$ Hours). Students are paid \EUR{} $10.30$ per hour working actively in various tasks at the base of life in SISSA, lasting from $50$ to $150$ hours depending on your availability, such as taking part in the Library administration, keeping the SISSA webpages updated, and so on. This income is tax-free. \textit{First year students cannot apply}, but keep this in mind in view of the following years. You can find more information \href{http://wiki.sissa.it/students/index.php/150_hours}{here};
     
-    \item a \textbf{contribution for non-EU students to travel back home}. The maximum amount of the contribution is \EUR{} $500.00$. This can be used only once during the PhD and after two years of work at SISSA (i.e. third or forth years students only). The capital city of the homeland must be more than 1000 km far from Trieste. In order to get the contribution, you should fill in the relevant form, enclose a copy of the travel receipt and your boarding pass and bring them all to the Students Secretariat. For more information visit this \href{http://wiki.sissa.it/students/index.php/Travel_grant_contribution}{webpage};
+    \section{Contribution for flying back home}
+    A \textbf{contribution for non-EU students to travel back home}. The maximum amount of the contribution is \EUR{} $500.00$. This can be used only once during the PhD and after two years of work at SISSA (i.e. third or forth years students only). The capital city of the homeland must be more than 1000 km far from Trieste. In order to get the contribution, you should fill in the relevant form, enclose a copy of the travel receipt and your boarding pass and bring them all to the Students Secretariat. For more information visit this \href{http://wiki.sissa.it/students/index.php/Travel_grant_contribution}{webpage};
     
-    \item students who are forced to interrupt their activity due to \textbf{illness}, \textbf{severe personal problems} or \textbf{pregnancy} may be granted a contribution equal to $70\%$ of the fellowship for a maximum period of $5$ months. However, if you are working in a SISSA lab, in case of pregnancy your fellowship freezes starting from the day you notify the Students Secretariat and the Director by sending them a certificate vouching for your pregnancy. You will get a contribution equivalent to $70\%$ of the scholarship starting from the day of the notification of your pregnancy and ending seven months after the birth of your child. Also the date of your PhD defense is postponed by the appropriate length of time. Moreover, the Italian State provides for addition support to pregnant women. In order to gain access to these grants, you must be registered to the INPS pension fund called ``Gestione Separata'' (see Chapter \ref{sec:gestione_separata_inps} for more information);
+   
+   \section{Kindergarten}
+   
+   
+   The ``\textbf{SISSA per i piccoli}{}'' Kindergarten is open to all SISSA staff, including students, to take care of your children during working hours. For further information, see the dedicated \href{https://www.sissa.it/kindergarten}{webpage}.
+   
     
-    \item non-EU students are entitled to a reimbursement of the amount of money paid to register with the \textbf{Italian national health system}, up to a maximum of \EUR{} $198$ per year;
+    \section{Registration SSN}
+    Non-EU students are entitled to a reimbursement of the amount of money paid to register with the \textbf{Italian national health system}, up to a maximum of \EUR{} $198$ per year;
     
-    \item a contribution towards expenses for training and research activities may be assigned to PhD students enrolled in either their third \textbf{or} fourth year of the course. This contribution is, in particular, aimed to support the self-promotion of students during their search for postdoctoral position. The amount of money given is \EUR{} $1000$ and can be credited \textbf{una tantum} upon \textbf{request} of the student. For more detailed explanation, see the dedicated \href{https://wiki.sissa.it/students/index.php/Training_and_research_contribution}{webpage}.
-\end{itemize}
+
 
 
 \chapter{\texorpdfstring{\faTags\ }{}ARDiS Support and Contributions}
@@ -478,7 +672,12 @@ It is possible for you to get also the \textbf{CUS card} and join the sports act
 external facilities which have a partnership agreement with the CUS. More information can be found on the \href{http://www.cus.units.it/home.php}{CUS website}.
 
 
-\chapter{\texorpdfstring{\faCommentMedical\ }{}Psychological Counselling and the Wellbeing Committee }
+\chapter{\texorpdfstring{\faCommentMedical\ }{}The Wellbeing Committee }
+
+The \textbf{Committee for Wellbeing} (``Comitato Unico di Garanzia'' in Italian, or CUG) proposes and verifies the results of positive actions for the realization of equal opportunities, improvement of the organizational well-being, removal of all types of discriminations and moral or psychological harassment, particularly if based on gender, age, sexual orientation, ethnicity, religion, language, belief and policies on disability conditions. It can be addressed by all people working and studying at SISSA.\\
+E-mail address: \linkemail{cug@sissa.it}; more info at this \href{http://www.sissa.it/committee-wellbeing-cug}{webpage}.
+
+\section{Psychological Counselling}
 
 Both SISSA and ARDiS offer a \textbf{free psychological counseling service} in order to identify individual and relational problems associated with adapting to academic life, preventing conflicts and 	discomforts, improving students' abilities to understand themselves and the others, providing support on topics such as emotional education, sexuality, and management of emotions. The people to contact are:
 \begin{itemize}
@@ -489,90 +688,25 @@ Both SISSA and ARDiS offer a \textbf{free psychological counseling service} in o
 	\item ARDiS psychological counselling service at 	\textbf{Tel: }$040 \, 309774$, \textbf{Cell. }$392 \, 5529489$, \textbf{E-mail:} {\linkemail{psicologo.trieste@ardiss.fvg}} See also the \href{http://www.ardiss.fvg.it/contenuti.php?view=page&id=46}{dedicated webpage} (the website is in Italian, but the service is also available in English).
 \end{itemize}
 
-To analyze and possibly solve various problems that students may experience during their academic life, the School has introduced two further institutional roles:
+\section{The Trusted Advisor}
 
-\begin{itemize}
-	\item the \textbf{Ombudsperson} is an independent, neutral and confidential resource for the students and the postdocs. He is the person to go to whenever one encounters a problem with his/her supervisor, on either a scientific or personal level, e.g. inconclusive research project, hampering of one's personal approach to pursue their career, and so on. The typical duties of these figures are: to investigate students complaints and attempt to solve them, usually through recommendations or mediation practices; to identify systematic issues that lead to poor assistance or breaches of students' rights; removal of all types of discriminations and moral or psychological harassment for all people working and studying at SISSA. For any problems related to the above points, please contact one of the three Ombudspersons: \textbf{Prof. Nicola Gigli} (\linkemail{ngigli@sissa.it}), \textbf{Prof. Daniele }\textbf{Amati} (\linkemail{amati@sissa.it}), \textbf{Prof.ssa Emilia Mezzetti} (\textbf{UniTs}) \textbf{}(\linkemail{mezzette@univ.trieste.it}). More info on the \href{http://students.sissa.it/issues/ombudsperson.html}{students' representatives website}.
-	
-	\item The \textbf{Trusted Advisor} or \textbf{Confidential Counsellor }(``Consigliere o Consulente di Fiducia'' in Italian) is a figure appointed to collect reports on acts of discrimination, sexual and moral harassment and mobbing. His/her purpose is to find any concrete remedy to these acts, through prevention and resolution. He/she is external to SISSA and collaborates with the CUG (see below). The Trusted Advisor in charge is \textbf{Dott.ssa Giovanna Galifi} (\linkemail{ggalifi@sissa.it}).
-\end{itemize}
+ The \textbf{Trusted Advisor} or \textbf{Confidential Counsellor }(``Consigliere o Consulente di Fiducia'' in Italian) is a figure appointed to collect reports on acts of discrimination, sexual and moral harassment and mobbing. His/her purpose is to find any concrete remedy to these acts, through prevention and resolution. He/she is external to SISSA and collaborates with the CUG (see below). The Trusted Advisor in charge is \textbf{Dott.ssa Giovanna Galifi} (\linkemail{ggalifi@sissa.it}).
+ 
+ \section{The Ombudsperson}
 
-The \textbf{Committee for Wellbeing} (``Comitato Unico di Garanzia'' in Italian, or CUG) proposes and verifies the results of positive actions for the realization of equal opportunities, improvement of the organizational well-being, removal of all types of discriminations and moral or psychological harassment, particularly if based on gender, age, sexual orientation, ethnicity, religion, language, belief and policies on disability conditions. It can be addressed by all people working and studying at SISSA.\\
-E-mail address: \linkemail{cug@sissa.it}; more info at this \href{http://www.sissa.it/committee-wellbeing-cug}{webpage}.
+The \textbf{Ombudsperson} is an independent, neutral and confidential resource for the students and the postdocs. He is the person to go to whenever one encounters a problem with his/her supervisor, on either a scientific or personal level, e.g. inconclusive research project, hampering of one's personal approach to pursue their career, and so on. The typical duties of these figures are: to investigate students complaints and attempt to solve them, usually through recommendations or mediation practices; to identify systematic issues that lead to poor assistance or breaches of students' rights; removal of all types of discriminations and moral or psychological harassment for all people working and studying at SISSA. For any problems related to the above points, please contact one of the three Ombudspersons: \textbf{Prof. Nicola Gigli} (\linkemail{ngigli@sissa.it}), \textbf{Prof. Daniele }\textbf{Amati} (\linkemail{amati@sissa.it}), \textbf{Prof.ssa Emilia Mezzetti} (\textbf{UniTs}) \textbf{}(\linkemail{mezzette@univ.trieste.it}). More info on the \href{http://students.sissa.it/issues/ombudsperson.html}{students' representatives website}.
 
 
-\chapter{\texorpdfstring{\faFutbol\ }{}Extracurricular Activities}
-
-But enough with the boring and serious stuff! SISSA also cares about your leisure activities. Apart from the gym and the music room, these are some other extracurricular activities you can entertain yourself with.
 
 
-\section{SISSA Club}
-
-The \textbf{SISSA Club} offers you the possibility to attend many different activities which can also be proposed by the students and changed every year. Some examples include \textbf{sports, drawing classes, acting lessons, choir, dancing courses, photography classes, and a weekly cineclub}. 
-
-In the park (more precisely, in the B5 building), you may find the \textbf{Gym}. It is actually managed by the SISSA Club members that organize \textbf{fitness courses}. There you can work out and exercise, following the Latin motto ``\textit{mens sana in corpore sano}{}'' (``a sane mind in a healthy body''). 
-
-\textbf{Language courses}, including Italian for foreigners, are also among the available options in addition to scientific English courses. A subscription fee is required to join the Club: it will also cover your insurance if you participate in the sport activities. The SISSA Club can also admit people that are not in SISSA but want to enjoy time with us. For more information, please visit the \href{http://club.sissa.it/}{SISSA Club website}. 
 
 
-\section{SISSA for Schools}
-
-SISSA also opens its doors to guided visits to the School and the park for schools (ranging from primary to high school institutions). This project, called ``\textbf{SISSA for Schools}{}'' \ (``SISSA per la Scuola'' in Italian), is organized by \textbf{SISSA Medialab}, a SISSA spin-off company involved in science communication and many different activities. Weekly, seminars and other entertaining activities are offered to children with the aim of popularizing science. With the same aspiration, the ``\textbf{Student day}'' is yearly organized to host about 500 high school students willing to discover SISSA's research topics directly from students and professors. If you are interested in science communication, you are welcome to join the program and become a lecturer or a guide for the tours.  For the volunteers, SISSA Medialab organizes a training course in creative science communication for researchers (usually called ``\textit{Science dialogues}''). You can find additional information \href{http://medialab.sissa.it/sissaperlascuola/en}{here}.
 
 
-\section{Welcome Day and SISSA Parties}
+\addcontentsline{toc}{part}{Part III - Other Administrative Services}
+\chapter{\texorpdfstring{\faNewspaper\ }{}Media Relations and Communications Unit}
 
-At the beginning of the academic year, a presentation of SISSA -- probably less interesting than the one you are reading {\dots} -- will take place in the Auditorium (Aula Magna) placed in front of the garden: this is the \textbf{Welcome Day} dedicated to first-year students. This is only one of the many social occasions where you will be able to get to know all your colleagues and new friends from SISSA, like the celebrated \textbf{SISSA Parties}. Remember that, among the secret mottoes of SISSA, there is: \textit{Study hard, party harder!} (The official one is ``ma per seguir virtute et canoscenza'', that is ``to follow virtue and knowledge'', quote from Dante's Inferno.) 
-
-
-\section{Neuroscience Experiments}
-
-An easy way to get some money and contribute to the advancement of science is to participate in the \textbf{experiments} that your colleagues from the Neuroscience Area conduct every day. These are announced on the Facebook group \href{https://www.facebook.com/groups/144096472323480}{``\textbf{Esperimenti SISSA}''} and also advertised via an e-mail newsletter from time to time; if you choose to help a neuroscientist out, you will be paid for your participation!
-
-
-\chapter{\texorpdfstring{\faFlag\ }{}Student Representatives}
-
-If you are having some issues during your time at SISSA or you are simply curious about how the School works, the \textbf{student representatives} are there to help. Each PhD course has its own representative(s), who sit on the Area Council where all the important matters about your scientific Area are discussed (there are also \textit{supplementary} representatives in order to ensure the quorum is met). You will meet your representative(s) at the \emph{Student Council} presentation at the start of your PhD course. You can find the names and photos of all the representatives on the notice board in the Cafeteria, on the \href{http://students.sissa.it/}{website} and at the end of this section. Do not hesitate to write to them at \linkemail{studentreps@sissa.it} if you have any questions or problems related to your daily life in SISSA.
-
-Collectively, the student representatives constitute the \textbf{Student Council}. The Student Council is an advisory body concerned with decisions related to students' activities in the School, with a particular focus on teaching activities. The Council elects a President and a Vice-President. The President transmits the requests of the Council to the Director and to the Academic Senate, and submits an annual report on teaching activities and students' life in the School during the ordinary meetings of the School Council. The Student Council meets on a monthly basis to discuss all issues which are relevant to the whole student body and to convey those issues to the appropriate committees.
-
-In addition to the student representatives in the Area councils, there are representatives also in the
-\begin{itemize}
-    \item \textbf{Governing Bodies} of the School, which are the
-    \begin{itemize}
-        \item \textbf{Academic Senate}, which has the function of proposing general and strategic planning and coordinating the educational and scientific activities of the School;
-        \item \textbf{Board of Directors}, which has the power to approve the strategic planning, one-year and three-year financial plans and the personnel planning, as well as to monitor the financial sustainability of School activities;
-    \end{itemize}
-    \item \textbf{Advisory Bodies} of the School, which are the
-    \begin{itemize}
-        \item \textbf{School Council}, which is the consultative body that gathers all the School academic personnel (student representatives and research personnel) and technical and administrative personnel;
-        \item \textbf{Student-Professor Joint Committee}, which monitors the educational offerings, the quality of teaching and the quality of the services provided to students by the academic personnel;
-    \end{itemize}
-    \item \textbf{Supervisory Bodies} of the School, which are the
-    \begin{itemize}
-        \item \textbf{Evaluation Committee}, which is the body in charge of evaluating the quality of the teaching and research activities carried out by the academic personnel;
-        \item \textbf{Quality Assurance Unit}, which manages the implementation of the quality assurance procedures according to the guidelines defined by the Governing Bodies.
-    \end{itemize}
-\end{itemize}
-
-The Student-Professor Joint Committee, the Quality Assurance Unit and the Evaluation Committee work together in the quality assurance system developed by the School. SISSA is in fact dedicated to ensuring the high quality and continuous improvement of its academic standards. The School has developed and maintains periodic internal quality assurance policies and procedures with the involvement of all stakeholders to strengthen the quality culture within the institution. In order to measure the students degree of satisfaction about teaching and research activities, students' services and employability, the School carries out an annual students' survey that is solely for students officially enrolled in PhD courses at SISSA.
-
-For more information about the School quality assurance system visit \href{https://www.sissa.it/qualita}{this website}. You can find more information on the organization of the School's governing bodies on the dedicated \href{https://www.sissa.it/general-organization}{page}.
-
-It is a duty and pleasure for all the student representatives to help you get the best from your experience as a SISSA fellow. Feel free to contact them, either in person or by dropping them a line.
-
-Important updates relevant to students can also be found on a Facebook page managed by the student representatives themselves, click \href{https://www.facebook.com/groups/sissastudents/}{here} for jumping to it.
-
-% --- POSTER OF THE REPRESENTATIVES --- %
-\begin{figure}
-    \vspace*{-12pt}
-    \includegraphics[height=1.05\textheight,center]{StudentPoster}
-\end{figure}
-
-
-\chapter{\texorpdfstring{\faNewspaper\ }{}Press Office (Media Relations and Communications Unit)}
-
-The \textbf{SISSA Media Relations and Communications Unit} is in charge of managing media relations, social media and the SISSA website homepage. It takes care of preparing press releases, press reviews and the development of media products. Moreover, the Unit oversees the School's visual identity and organizes some of the School outreach events. If you are interested in promoting your research in the media, you are willing to take part in outreach initiatives or you have any enquiry concerning communication activities, please write to \linkemail{pressoffice@sissa.it} or contact any member of the \href{https://www.sissa.it/media-and-press}{Media Relations and Communications Unit}. Please also note that the SISSA logo, letterhead and PowerPoint templates are available at \href{https://www.sissa.it/researchers-and-sissa-staff}{this webpage}.
+The \textbf{SISSA Media Relations and Communications Unit} (better known as Press Office) is in charge of managing media relations, social media and the SISSA website homepage. It takes care of preparing press releases, press reviews and the development of media products. Moreover, the Unit oversees the School's visual identity and organizes some of the School outreach events. If you are interested in promoting your research in the media, you are willing to take part in outreach initiatives or you have any enquiry concerning communication activities, please write to \linkemail{pressoffice@sissa.it} or contact any member of the \href{https://www.sissa.it/media-and-press}{Media Relations and Communications Unit}. Please also note that the SISSA logo, letterhead and PowerPoint templates are available at \href{https://www.sissa.it/researchers-and-sissa-staff}{this webpage}.
 
 
 \chapter{\texorpdfstring{\faUserShield\ }{}Health and Safety Management}
@@ -588,113 +722,6 @@ In SISSA there is a portable defibrillator that can be used only by authorized p
 Remember also that if you want to bring from home some additional chairs, tables, electric boilers and so on, they have first to be approved by this office. For any other issue you can contact the Health and Safety Management at \linkemail{safety@sissa.it}. More info can be found on this \href{http://www.sissa.it/safety}{website}.
 
 
-\chapter{\texorpdfstring{\faShieldVirus\ }{}SISSA During the COVID-19 Saga}
-
-In this chapter you can find essential information on the procedures that SISSA has employed in order to safeguard everybody's health in these tough times. Moreover, we also provide some useful tips with the hope of making your work at SISSA's facilities as comfortable as possible! \\
-This information is summarised below in the form of an FAQ. Visit SISSA's \href{https://www.sissa.it/news/covid-19-access-sissa-and-schools-activities}{webpage} for more details.
-
-
-\section{Can I Access SISSA?}
-
-All SISSA students are allowed to access the campus without specific authorisation. Within the School's opening hours, you can carry out both individual and lab-based research activities. Of course, common sense has to be applied! As always, we must keep a safe distance between each other and avoid grouping up. For this reason, you are strongly encouraged to work from home, unless coming to SISSA turns out to be strictly necessary or essential for your working well-being. \\
-Note that the use of spaces for research activities must comply with safety standards (e.g., distancing, use of PPE, etc.). So check for the presence of other people in shared offices and laboratories ahead of time, and book the facilities and common areas: in this way you will be able to work in peace and safety. \\
-If you have medical conditions which put you at a higher risk for COVID-19, please follow the directions provided by the Human Resources Office (e-mail: \linkemail{risorseumane@sissa.it}) and consult your healthcare provider (general practitioner or specialist) or SISSA's company doctor.
-
-
-\section{How Can I Get to SISSA?}
-
-\begin{itemize}
-    \item \textbf{By private vehicle or on foot} - The use of private vehicles must include only the presence of the driver if possible; if you want to bring someone with you, both of you must wear a facial mask or other protective equipment for covering your nose and mouth. During the trip, avoid the use of air conditioning and especially the recirculation function. These limits do not apply if vehicle occupants are cohabitants. It is recommended to arrive at SISSA between 8 AM and 8.30 AM to avoid creating long queues to enter with those using the private shuttle (see below).
-    
-    \item \textbf{By the SISSA shuttle} - If you do not have your own means of transport, or you prefer not to use it, you can use the shuttle service that SISSA has set up due to the COVID-19 emergency. The shuttle departs from the city centre and operates from Monday to Friday, excluding public holidays, with the following times and stops:
-    \begin{itemize}
-        \item Inbound: 7.55 AM (Largo Barriera) - 8 AM (Piazza Oberdan) - 8.25 AM (SISSA)
-        \item Inbound: 8.30 AM (Largo Barriera) - 8.35 AM (Piazza Oberdan) - 9 AM (SISSA)
-        \item Inbound: 9 AM (Largo Barriera) - 9.05 AM (Piazza Oberdan) - 9.30 AM (SISSA)
-        \item Outbound: 1:15 PM (SISSA) - 1:40 PM (Piazza Oberdan) - 1:45 PM (Largo Barriera)
-        \item Outbound: 7 PM (SISSA) - 7:25 PM (Piazza Oberdan) - 7:30 PM (Largo Barriera)
-    \end{itemize}
-    Remember that bookings are compulsory, and must be made before Thursday 8 AM the week in advance. On the shuttle, you must wear suitable protective equipment for covering the nose and mouth and respect a one-meter safety distance at least. In order to allow for social distancing, the shuttle will have limited capacity: only one person can use a seat row, with the exception of spouses or cohabiting family members. In the latter case it is sufficient to book 1 seat. \\
-    You can reserve your place on the shuttle \href{https://sissa-my.sharepoint.com/:x:/g/personal/tomicich_sissa_it/EawtTu5bUChBou8M1yikFLwB8AhuiMMCR-zscX84sRPWrQ?rtime=VgDdcu692Eg}{here}.
-    
-    \item \textbf{By public transport services} - As a (riskier) alternative, the bus line 38 is still active, while the bus number 64 will reach SISSA as soon as the extension of the square in front of the SISSA entrance has been completed.
-\end{itemize}
-
-
-\section{How Should I Behave Inside SISSA?}
-
-The maximum number of people who may be present at the same time in each shared room has been fixed for all areas in the main building, based on the overall amount of protection devices offered by SISSA to prevent the contagion, the available space, the time of stay and the activity carried out in a specific workplace. \\
-To avoid the so-called ``close contact'', it is necessary to ensure a low density of people and the respect of a minimum interpersonal distance of: 1 metre in transit areas (corridors); 2 metres in ``critical'' rest areas (coffee-break areas, smoking areas, etc.) and, unless otherwise specified, in common areas (including offices with more than one person). Note that a ``close contact'' is defined as a contact that occurs in a restricted environment (e.g. office) continuously for 15 minutes or more with an interpersonal distance of less than 2 metres.
-
-
-\subsection{Masks, Distances and Hygiene Measures}
-
-Keep a safe distance of at least 1 metre. In the corridors, on the stairs, in the bathrooms and in all common areas it is always recommended to wear the surgical mask provided at the entrance or the one in your possession, if considered suitable by the reception staff. Reduce your movements inside the SISSA building to those that are really necessary for your activity. Wash your hands frequently with soap and water, or alternatively with the dedicated cleansers placed on each floor of the School.
-
-
-\subsection{Cleaning the Workstation}
-
-Do not forget to clean frequently your desk and your workstation by means of the appropriate detergents. Be especially careful to clean well the infamous mouse-keyboard couple.
-
-
-\subsection{Ventilation of the Premises}
-
-Finally, it is a good idea to aerate your office as often as possible, so as to reduce further the probability of the infection transmission.
-
-
-\section{What About the Bar and Canteen Services?}
-
-As of \today\ the take-away service offered by the canteen is operative in a limited fashion, offering sandwiches, piadinas, pizza slices, salads and hot meals as well.
-
-Meals must be booked before 11 AM and collected between 12 PM and 1:30 PM. Bookings can be made:
-\begin{itemize}
-    \item through \href{https://www.sissa.it/cafeteria}{this link};
-    \item by e-mailing \linkemail{ristobar@sissa.it};
-    \item by using the paper register at the Reception.
-\end{itemize}
-
-If you are interested in receiving updates and communications from the canteen service via e-mail, you can subscribe to the cafeteria mailing list. This can be done by filling out the form that you find at \href{https://go.sissa.it/cafeteria}{this webpage} or by sending an e-mail from the address you want to subscribe with.
-
-\begin{comment}
-As of \today\ the bar is fully operational and open from 9:00 to 11:00 and from 14:00 to 15:00, while the canteen is open from 12:00 to 14:00.
-
-You can eat plated canteen food in the canteen by booking a specific time and place beforehand at \url{https://services.sissa.it/mensa/}. You can also get take-away meals (but \textbf{not} eat them in the canteen, even if you've booked a table) even without booking them in advance.
-
-If instead you prefer to get takeaway sandwiches/piadinas/salads, if have to book them in advance (by 11:00) in one of the following ways:
-\begin{itemize}
-    \item on \url{https://www.sissa.it/cafeteria}
-    \item by sending an email to \linkemail{ristobar@sissa.it}
-    \item via the paper register at the reception
-\end{itemize}
-Sandwiches/piadinas/salads can then be collected at the canteen from 12:00 to 14:00.
-\end{comment}
-
-
-\section{Where Can I Retrieve Information on the Current Library Timetable and Rules?}
-
-Luckily, everything has a place in this world. \href{https://library.sissa.it/new-library-timetable-rules}{Here} you will find all the latest news on the status of the Library services.
-
-
-\section{Smart Working Toolbox}
-
-We list below some useful tips and reminders that hopefully could make your research activity at home more comfortable and less tiresome.
-\begin{itemize}
-    \item Did you know that SISSA provides each member of its academic staff with a Basic Zoom account for free? This allows you to organize virtual meetings with no time restrictions due to the number of people participating (as it occurs for the free subscription). Visit \url{https://www.itcs.sissa.it/lecturesonline} for more details!
-    
-    \item Not only Zoom, but also Overleaf has a special agreement with SISSA. You can claim your free Overleaf Professional account by signing up with a SISSA email (or by adding it to an existing Overleaf account). Notice that a Professional subscription poses no limits to the number of collaborators which you can share your projects with! More info: \url{https://www.overleaf.com/edu/sissa}.
-    
-    \item During your everyday research activity you may want to access the SISSA network remotely. Possible reasons: necessity of connecting to your workstation, extreme need of computational resources on the Ulysses cluster, exploiting the opportunity of having direct access to scientific papers (otherwise protected by paywalls) through the holy SISSA identity key. What you need is to establish a VPN remote connection with the SISSA internal network: follow the instructions at \url{https://www.itcs.sissa.it/services/computing/networkaccess}.
-    
-    \item Other tools that can help you get access to scientific papers while you are off-campus are also \href{https://scholar.google.com/intl/en/scholar/help.html\#access}{Google Scholar's Off-Campus Access}, that works by storing your library subscriptions for 30 days when you visit Google Scholar while on campus, \href{https://scholar.google.com/scholar_settings?sciifh=1\&as_sdt=0,5\#2}{Google Scholar's Library Links}, that lets you add a SISSA Library link next to every search result, and awesome free and open-source (fully legal) browser extensions like \href{https://unpaywall.org}{Unpaywall} (Chrome, Firefox), \href{https://www.oahelper.org}{Open Access Helper} (iOS, Safari on MacOS, Chrome, Firefox) and \href{https://openaccessbutton.org}{Open Access Button} (Chrome, Firefox, or by manually entering the DOI). If you also have a UniTS account, Open Access Helper lets you automatically use its EZProxy (more details \href{https://www.oahelper.org/ezproxy/}{here}) by just looking for ``units'' during the initial configuration.
-    
-    \item At these challenging times for our daily as well as academic life, SISSA has taken advantage of the Campus Initiative of Coursera, the leading platform for online learning. We encourage you to take a look at the courses available within the SISSA-Coursera agreement by registering at \href{https://www.coursera.org/programs/sissa-on-coursera-dkw8c}{this link} by using your SISSA e-mail. Should you find one or more courses that you wish to follow, please send an email to the Students Secretariat (e-mail: \linkemail{phd@sissa.it}) in order to have your account activated. Just a notice: some students reported that one needs to complete a course to have the possibility to subscribe to another one. You will not able to follow two different courses at the same time under the actual license rights.
-    
-    \item What would you say if we told that you are allowed to borrow the monitor of your workstation for the benefit of your home-made research? To do so, you have to write to prof. Antonio Lanza (e-mail: \linkemail{lanza@sissa.it}) with the inventory number of the monitor that you wish to get on loan. Make sure that the coordinator of your PhD sector is CC'd in your e-mail!
-\end{itemize}
-
-\section{The Final Piece of the Puzzle: Your Feedback!}
-We representatives are deeply aware of the continuing difficulties regarding your daily relationship with PhD-related activities, ranging from keeping in contact with your supervisor (a tough challenge in itself, sometimes) to even just managing to do some clean research without thinking excessively about the current situation. \\
-Do not hesitate to contact us should you have any problem regarding your PhD life, even if you do not understand some boring, bureaucratic stuff and you feel the need for some advice. We are still here for bridging the gap between your needs and the current workflow of SISSA.
 
 
 \chapter{\texorpdfstring{\faAddressBook\ }{}Miscellaneous Contacts}


### PR DESCRIPTION
I have just reorganised the content of the Vademecum, splitting some chapters, moving sections in more suitable positions and creating a macro division in the table of contents. The contents of each chapter is essentially unchanged.